### PR TITLE
refactor: improve skip[to] performance O(log i)

### DIFF
--- a/be_indexer_test.go
+++ b/be_indexer_test.go
@@ -400,7 +400,7 @@ func TestBEIndex_Retrieve2(t *testing.T) {
 	LogLevel = ErrorLevel
 
 	convey.Convey("test index and simple bench for kGroup/Compacted indexer", t, func() {
-		docs, queries := BuildTestDocumentAndQueries(100000, 100, true)
+		docs, queries := BuildTestDocumentAndQueries(500000, 100, true)
 		b := NewIndexerBuilder()
 		cb := NewCompactIndexerBuilder()
 		for _, doc := range docs {

--- a/entries_holder.go
+++ b/entries_holder.go
@@ -100,19 +100,11 @@ func (h *DefaultEntriesHolder) AddFieldEID(field *FieldDesc, values Values, eid 
 			return fmt.Errorf("field:%s parser value:%+v fail, err:%s", field.Field, value, err.Error())
 		}
 		for _, id := range ids {
-			h.AppendEntryID(NewKey(field.ID, id), eid)
+			key := NewKey(field.ID, id)
+			h.plEntries[key] = append(h.plEntries[key], eid)
 		}
 	}
 	return nil
-}
-
-func (h *DefaultEntriesHolder) AppendEntryID(key Key, id EntryID) {
-	entries, hit := h.plEntries[key]
-	if !hit {
-		h.plEntries[key] = Entries{id}
-	}
-	entries = append(entries, id)
-	h.plEntries[key] = entries
 }
 
 func (h *DefaultEntriesHolder) getEntries(key Key) Entries {

--- a/example/compacted_indexer/compacted_index.go
+++ b/example/compacted_indexer/compacted_index.go
@@ -152,7 +152,7 @@ func QueryTest(index be_indexer.BEIndex) {
 	start := time.Now().UnixNano() / 1000000
 	cnt := 0
 	for _, ass := range assigns {
-		ids, _ := index.Retrieve(ass)
+		ids, _ := index.Retrieve(ass, be_indexer.WithStepDetail())
 		cnt += len(ids)
 	}
 	fmt.Println("avg result len:", float64(cnt)/float64(len(assigns)))

--- a/roaringidx/be_container_ac.go
+++ b/roaringidx/be_container_ac.go
@@ -137,7 +137,7 @@ func (c *ACBEContainer) BuildBEContainer() (BEContainer, error) {
 	var err error
 	keys := make([][]rune, 0, len(c.incValues))
 	if len(c.incValues) > 0 {
-		for kw, _ := range c.incValues {
+		for kw := range c.incValues {
 			keys = append(keys, []rune(kw))
 		}
 		c.inc = &aho.Machine{}
@@ -148,7 +148,7 @@ func (c *ACBEContainer) BuildBEContainer() (BEContainer, error) {
 
 	if len(c.excValues) > 0 {
 		keys = keys[:0]
-		for kw, _ := range c.excValues {
+		for kw := range c.excValues {
 			keys = append(keys, []rune(kw))
 		}
 		c.exc = &aho.Machine{}


### PR DESCRIPTION
skip[to] use a improved search https://en.m.wikipedia.org/wiki/Exponential_search
Why: 
Exponential search can also be used to search in bounded lists. Exponential search can even out-perform more traditional searches for bounded lists, such as binary search, when the element being searched for is near the beginning of the array. This is because exponential search will run in O(log i) time, where i is the index of the element being searched for in the list, whereas binary search would run in O(log n) time, where n is the number of elements in the list.