### PR TITLE
feature: add lt gt expression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,30 @@
 
 ## Boolean expression index
 
-![design](./doc/yahoo-indexer.png):
 
-算法描述来源于论文：[Boolean expression indexing](https://theory.stanford.edu/~sergei/papers/vldb09-indexing.pdf),代码中也附带
-了一份pdf[doc/vldb09-indexing.pdf](doc/vldb09-indexing.pdf).
+算法描述来源于论文：[Boolean expression indexing](https://theory.stanford.edu/~sergei/papers/vldb09-indexing.pdf),
+代码中附带了一份pdf[doc/vldb09-indexing.pdf](doc/vldb09-indexing.pdf).索引数据构建后的示意图见:
+[boolean indexing arch](doc/vldb09_indexing.md),本库的作用是为了使用统一且规范的方式解决下面这种问题:
+
+```bash
+# 对于一系列规则(布尔规则)描述数据; 对于一个输入.判断哪些规则满足条件的库
+# 广告/商品检索便是典型的例子, 某些规则引擎也非常合适
+
+dataset:
+item1:  {city in [city1, city2] && isVIP is true}
+item2:  {age > 18 && city not in [city1, city2] && isVIP is true}  #(eg: aldult video)
+.... 0-亿级别如此的数据; 当然更多数据建议使用工程分片实现更快的检索
+
+当给定一个数据:
+<=
+city: beijing
+age:  24
+tag:  [xx-fans, xx, xx, xxx] # 多值特征
+vip:  true|fals
+
+检索输出数据中所有满足布尔条件描述限制的条目:
+=> [item1, itemn, .....]
+```
 
 为什么写它:
 - 大佬(Wolfhead)的实现并没有开源
@@ -13,17 +33,31 @@
 - 在线广告很多功能模块借助其可以实现非常优雅的代码实现
 - 论文仅仅描述了核心算法逻辑,没有给出类似于多值查询等其他工程时实践和扩展的设计建议
 
-本库是基于[C++实现移步](https://github.com/echoface/ltio/blob/master/components/boolean_indexer)逻辑的基础上，进行整理改进之后的版本
+本库是基于[C++实现移步](https://github.com/echoface/ltio/blob/master/components/boolean_indexer)逻辑的基础上，
+进行整理改进之后的版本, 因为存在对信息存在编码和压缩，所以存在一些限制，使用时注意规避;
 
-因为存在对信息存在编码和压缩，所以存在一些限制，使用时注意规避:
 - 文档ID最大值限制为:`[-2^43, 2^43]`
+  - YES: 支持负值
 - 每个文档最多拥有256个Conjunction
-- 每个DNF最大支持组合条件(field)个数：256
+  - 自定义Container不受此限制, 见Default容器的实现
+- 每个DNF最大支持组合条件(field)个数256
+  - 自定义Container不受此限制, 见Default容器的实现
 - 支持自定义Tokenizer，见parser的定义
-- 支持容器扩展(eg:外部kv存储); 默认容器是hashmap,因抽用了8bit存储field，所以最大值：2^56
-- 支持模式匹配逻辑查询(基于AC自动机,用于上下文内容定向等等)
+- 支持容器扩展(eg:外部kv存储); 默认容器实现使用go内置map存储
+  - 默认容器:不支持: <,>运算符
+- 内置支持模式匹配容器:(基于AC自动机,常用于上下文内容检索等)
+  - 模式匹配容器: 不支持: <,>运算符
+- 内置数值容器:支持>,in,< 等预算符,用于支持无限集合范围布尔表达
+  - PS: =,!=是in/notin的单值情况
+  - 常用于不方便由业务场景由业务转化具体枚举值的数值防伪
+  - 简而言之支持: {score > 20 && keywords in [x,x] && city not in [x,x]}
 
-在引入Aho-corasick模式匹配查找容器后，Indexer的构建可能失败，整个库中因为一些限制，不允许一些错误的出现，否则布尔逻辑可能失败，因此对不可恢复错误引入了panic，需要集成的应用自己recover对应的panic进行业务逻辑的处理，而对于AddDocument 等允许返回错误的借口，需要业务自行判断是否继续构建索引；目前当一个文档包含一个或者多个Conjunction时, 如果某个Conjunction 因提供的值不能被Parser/Holder 正确的解析成所需要的数据时,会跳过错误导致对应的文档不被索引到; 可以通过`WithBadConjBehavior` 指定具体的行为`ERR(default), Skip, Panic` 暴露此类问题或者检测对应的日志;
+在引入Aho-corasick模式匹配查找容器后，Index构建可能失败，因此对不可恢复错误引入了panic，
+需要集成的应用自己recover对应的panic进行业务逻辑的处理，而对于AddDocument等返回error的API，
+需要业务自行判断是否继续构建索引；目前当一个文档包含一个或者多个Conjunction时, 如果某个
+Conjunction因提供的值不能被Parser/Holder 正确的解析成所需要的数据时,会跳过错误导致对应的
+文档不被索引到; 可以通过`WithBadConjBehavior(Panic)` 指定具体的行为`ERR(default), Skip, Panic`
+暴露此类问题或者检测对应的日志;
 
 ### usage:
 
@@ -32,8 +66,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/echoface/be_indexer/parser"
-	"github.com/echoface/be_indexer/util"
+
 	"github.com/echoface/be_indexer"
 )
 
@@ -42,38 +75,34 @@ func buildTestDoc() []*be_indexer.Document {
 }
 
 func main() {
-	builder := be_indexer.NewIndexerBuilder()
+	builder := be_indexer.NewIndexerBuilder(
+		be_indexer.WithBadConjBehavior(be_indexer.SkipBadConj),
+	)
 	// or use a compacted version, it faster about 12% than default
 	// builder := be_indexer.NewCompactIndexerBuilder()
 
 	// optional special a holder/container for field
+	// dever can also register customized container: see: entries_holder_factory.go
 	builder.ConfigField("keyword", be_indexer.FieldOption{
-		Parser:    nil,
 		Container: be_indexer.HolderNameACMatcher,
 	})
 
 	for _, doc := range buildTestDoc() {
-		err := builder.AddDocument(doc)
-		util.PanicIfErr(err, "document can't be resolved")
+		_ = builder.AddDocument(doc) // see: document.go for how to construct doc
 	}
 
 	indexer := builder.BuildIndex()
 
-	result, e := indexer.Retrieve(map[be_indexer.BEField]be_indexer.Values{
-		"age": be_indexer.NewValues2(5),
-	})
-	fmt.Println(e, result)
+	// indexing satisfied docs
+	assigns := map[be_indexer.BEField]be_indexer.Values{
+		"age":  be_indexer.NewIntValues(1),
+		"city": be_indexer.NewStrValues("sh", "bj"),
+		"tag":  be_indexer.NewStrValues("tag1", "tagn"),
+	}
 
-	result, e = indexer.Retrieve(map[be_indexer.BEField]be_indexer.Values{
-		"ip": be_indexer.NewStrValues2("localhost"),
-	})
-	fmt.Println(e, result)
-
-	result, e = indexer.Retrieve(map[be_indexer.BEField]be_indexer.Values{
-		"age":  be_indexer.NewIntValues2(1),
-		"city": be_indexer.NewStrValues2("sh"),
-		"tag":  be_indexer.NewValues2("tag1"),
-	}, be_indexer.WithStepDetail(), be_indexer.WithDumpEntries())
+	result, e := indexer.Retrieve(assigns,
+		be_indexer.WithStepDetail(),
+		be_indexer.WithDumpEntries())
 	fmt.Println(e, result)
 }
 ```
@@ -83,11 +112,17 @@ func main() {
 
 ![design](./doc/indexer_design.png):
 
-基于roaring bitmap的布尔索引实现，相对于Boolean expression index论文的实现，是利用bitmap在集合运算方面的优势实现的DNF Match逻辑，目前支持普通的倒排以及基于AhoCorasick的字符串模式匹配逻辑实现。从benchmark 结果来看，在fields数量较多的场景下性能相对于Boolean expression index的实现性能相对来说要差一些，但是其可理解性要好一点。 借助roaring bitmap的实现，在文档数规模大、特征数较小的场景下可以节省大量的内存。aho corasick 选型上也选取了使用double array trie的实现，索引上内存有所压缩。
+基于roaring bitmap的布尔索引实现，区别于Boolean expression indexing论文的实现，
+利用bitmap在集合运算方面的优势实现的DNF Match逻辑，目前支持普通的倒排以及基于
+AhoCorasick的字符串模式匹配逻辑实现。从benchmark 结果来看，在fields数量较多的
+场景下性能相对于Boolean expression index的实现性能相对来说要差一些，但是其可理
+解性要好一点。 借助roaring bitmap的实现，在文档数规模大、特征数较小的场景下可以
+节省大量的内存。aho corasick 选型上也选取了使用double array trie的实现，索引上内存有所压缩。
 
-限制：
+NOTE：
 - 文档ID范围[-2^56, 2^56]
 - 单个Conjunction数量小于256个
+- 使用前需要为业务中出现的每个字段提前完成配置
 
 ### usage
 ```go

--- a/boolean_expr.go
+++ b/boolean_expr.go
@@ -83,6 +83,22 @@ func NewStrValues(v string, ss ...string) Values {
 	return append([]string{v}, ss...)
 }
 
+func NewGTBoolValue(value int64) BoolValues {
+	return NewBoolValue(ValueOptGT, value, true)
+}
+
+func NewLTBoolValue(value int64) BoolValues {
+	return NewBoolValue(ValueOptLT, value, true)
+}
+
+func NewBoolValue(op ValueOpt, value Values, incl bool) BoolValues {
+	return BoolValues{
+		Operator: op,
+		Incl:     incl,
+		Value:    value,
+	}
+}
+
 func (v *BoolValues) booleanToken() string {
 	if v.Incl {
 		return "inc"

--- a/doc/vldb09_indexing.md
+++ b/doc/vldb09_indexing.md
@@ -1,0 +1,4 @@
+## Boolean expression indexing
+
+## indexing data struct
+![design](./doc/yahoo-indexer.png):

--- a/document_test.go
+++ b/document_test.go
@@ -46,13 +46,13 @@ func TestConjunction_AddBoolExpr(t *testing.T) {
 
 		convey.So(conj.CalcConjSize(), convey.ShouldEqual, 1)
 
-		conj.AddBoolExpr(NewBoolExpr("ip", true, NewStrValues("localhost", "127.0.0.1")))
+		conj.AddBoolExprs(NewBoolExpr("ip", true, NewStrValues("localhost", "127.0.0.1")))
 		convey.So(len(conj.Expressions), convey.ShouldEqual, 3)
 
 		convey.So(conj.CalcConjSize(), convey.ShouldEqual, 2)
 
 		convey.So(func() {
-			conj.addExpression("age", true, 1)
+			conj.In("age", 1)
 		}, convey.ShouldPanic)
 
 	})

--- a/entries_holder_ex_ltgt.go
+++ b/entries_holder_ex_ltgt.go
@@ -5,147 +5,279 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/echoface/be_indexer/parser"
 	"github.com/echoface/be_indexer/util"
 )
 
 type (
-	EntriesWrap struct {
-		Field     BEField
-		plEntries Entries
-	}
-	// DefaultExLgtHolder EntriesHolder implement base on default holder extend support for LT/GT operator
-	DefaultExLgtHolder struct {
-		debug  bool
-		maxLen int64 // max length of Entries
-		avgLen int64 // avg length of Entries
+	// ExtendLgtHolder implement base on default holder extend support for LT/GT operator
+	ExtendLgtHolder struct {
+		debug      bool
+		maxLen     int // max length of Entries
+		avgLen     int // avg length of Entries
+		ltValueCnt int
+		gtValueCnt int
 
-		plEntries map[Key]Entries
-
-		// all "field < number" expression store here(sorted)
-		ltEntries []EntriesWrap
+		// in/not in expression hash container
+		plEntries map[int64]Entries
 
 		// all "field > number" expression store here(sorted)
-		gtEntries []EntriesWrap
+		// expr: A: age > 30
+		// expr: B: age > 20
+		// expr: C: age > 35
+		// expr: D: age > 20
+		// expr: E: age > 20
+		// gtEntries: [20, 30, 35] // sorted
+		//             |    |   |
+		//			   |    |   [C]
+		//             |    [A]
+		//             |[B, D, E]
+		gtEntries ValueEntries
+
+		// all "field < number" expression store here(sorted)
+		ltEntries ValueEntries
+
+		_ltmap map[int64]*LgtEntries
+		_gtmap map[int64]*LgtEntries
+
+		EnableF2I bool
 	}
-	prepareState struct {
-		op       ValueOpt
+
+	LgtEntries struct { // current default container can support max fields:256
 		lgtValue int64
-		valueIDs []uint64
+		entries  Entries
 	}
+
+	prepareData struct {
+		operator ValueOpt
+		lgtValue int64
+		valueIDs []int64
+	}
+
+	ValueEntries []*LgtEntries
 )
 
-func NewDefaultExtLtGtHolder() *DefaultExLgtHolder {
-	util.PanicIf(true, "WIP, don't use it now")
-	return &DefaultExLgtHolder{
-		plEntries: map[Key]Entries{},
+// Len Entries sort API
+func (s ValueEntries) Len() int           { return len(s) }
+func (s ValueEntries) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s ValueEntries) Less(i, j int) bool { return s[i].lgtValue < s[j].lgtValue }
+
+func NewDefaultExtLtGtHolder(f2i bool) *ExtendLgtHolder {
+	return &ExtendLgtHolder{
+		plEntries: map[int64]Entries{},
+		_ltmap:    map[int64]*LgtEntries{},
+		_gtmap:    map[int64]*LgtEntries{},
+		EnableF2I: f2i,
 	}
 }
 
-func (h *DefaultExLgtHolder) EnableDebug(debug bool) {
+func (h *ExtendLgtHolder) EnableDebug(debug bool) {
 	h.debug = debug
 }
 
 // DumpInfo
-// {name: %s, value_count:%d max_entries:%d avg_entries:%d}
-func (h *DefaultExLgtHolder) DumpInfo(buffer *strings.Builder) {
-	info := fmt.Sprintf("{name: %s, value_count:%d max_entries:%d avg_entries:%d}",
-		"default", len(h.plEntries), h.maxLen, h.avgLen)
-	buffer.WriteString(info)
+func (h *ExtendLgtHolder) DumpInfo(buffer *strings.Builder) {
+	infos := map[string]interface{}{
+		"name":          "ExtendLgtHolder",
+		"kvCnt":         len(h.plEntries),
+		"ltCnt":         len(h.ltEntries),
+		"gtCnt":         len(h.gtEntries),
+		"maxEntriesLen": h.maxLen,
+		"avgEntriesLen": h.avgLen,
+		"EnableF2I":     h.EnableF2I,
+	}
+	buffer.WriteString(util.JSONPretty(infos))
 }
 
-func (h *DefaultExLgtHolder) DumpEntries(buffer *strings.Builder) {
-	buffer.WriteString("DefaultEntriesHolder entries:")
-	for key, entries := range h.plEntries {
-		buffer.WriteString("\n")
-		buffer.WriteString(key.String())
-		buffer.WriteString(":")
+func (h *ExtendLgtHolder) DumpEntries(buffer *strings.Builder) {
+	buffer.WriteString("ExtendLgtEntriesHolder entries:\n>>kv entries")
+	for v, entries := range h.plEntries {
+		buffer.WriteString(fmt.Sprintf("\n%d:", v))
 		buffer.WriteString(strings.Join(entries.DocString(), ","))
+	}
+	buffer.WriteString("\n>>gt entries")
+	for _, data := range h.gtEntries {
+		buffer.WriteString(fmt.Sprintf("\n%d:", data.lgtValue))
+		buffer.WriteString(strings.Join(data.entries.DocString(), ","))
+	}
+	buffer.WriteString("\n>>lt entries")
+	for _, data := range h.ltEntries {
+		buffer.WriteString(fmt.Sprintf("\n%d:", data.lgtValue))
+		buffer.WriteString(strings.Join(data.entries.DocString(), ","))
 	}
 }
 
-func (h *DefaultExLgtHolder) CompileEntries() error {
+func (h *ExtendLgtHolder) CompileEntries() error {
 	h.makeEntriesSorted()
+
+	for v, lgtValueEntries := range h._gtmap {
+		util.PanicIf(v != lgtValueEntries.lgtValue, "something going wroing")
+		h.gtEntries = append(h.gtEntries, lgtValueEntries)
+	}
+	for v, lgtValueEntries := range h._ltmap {
+		util.PanicIf(v != lgtValueEntries.lgtValue, "something going wroing")
+		h.ltEntries = append(h.ltEntries, lgtValueEntries)
+	}
+	// no longer used after build, retrieve process use gtEntries/ltEntries
+	h.ltValueCnt = len(h._ltmap)
+	h.gtValueCnt = len(h._gtmap)
+	h._ltmap, h._gtmap = nil, nil
+
+	sort.Sort(h.ltEntries)
+	sort.Sort(h.gtEntries)
 	return nil
 }
 
-func (h *DefaultExLgtHolder) GetEntries(field *FieldDesc, assigns Values) (r EntriesCursors, e error) {
-	var ids []uint64
-
-	if ids, e = field.Parser.ParseAssign(assigns); e != nil {
+func (h *ExtendLgtHolder) GetEntries(field *FieldDesc, assigns Values) (r EntriesCursors, e error) {
+	var ids []int64
+	if ids, e = parser.ParseIntergers(assigns, h.EnableF2I); e != nil {
 		return nil, e
 	}
+	if len(ids) <= 0 {
+		return r, nil
+	}
+	minValudID, maxValudID := ids[0], ids[0]
 	for _, id := range ids {
+		minValudID = util.MinInt64(minValudID, id)
+		maxValudID = util.MaxInt64(maxValudID, id)
 
-		key := NewKey(field.ID, id)
-
-		if entries := h.getEntries(key); len(entries) > 0 {
+		if entries := h.getEntries(id); len(entries) > 0 {
 			r = append(r, NewEntriesCursor(newQKey(field.Field, id), entries))
+			LogInfoIf(h.debug, "kvs find:<%s:%d>, entries len:%d", field.Field, id, len(entries))
 		}
 	}
-	if len(ids) > 0 {
-		minValudID, maxValudID := int64(ids[0]), int64(ids[0])
-		for _, v := range ids {
-			minValudID = util.MinInt64(minValudID, int64(v))
-			maxValudID = util.MaxInt64(maxValudID, int64(v))
+	// [5, 15, 20, 21, 35, 40]
+	//                     <-
+	var data *LgtEntries
+	for j := h.ltValueCnt - 1; j >= 0; j-- {
+		data = h.ltEntries[j]
+		if data.lgtValue > minValudID {
+			key := newQKey(field.Field, data.lgtValue)
+			r = append(r, NewEntriesCursor(key, data.entries))
+			LogInfoIf(h.debug, "ltEntries find:<%s:%d,%d>, entries len:%d",
+				field.Field, data.lgtValue, minValudID, len(data.entries))
+			continue
 		}
+		break
 	}
-
+	// [5, 15, 20, 21, 35, 40]
+	// ->
+	for _, data = range h.gtEntries {
+		if data.lgtValue < maxValudID {
+			key := newQKey(field.Field, data.lgtValue)
+			r = append(r, NewEntriesCursor(key, data.entries))
+			LogInfoIf(h.debug, "gtEntries find:<%s:%d,%d>, entries len:%d",
+				field.Field, data.lgtValue, maxValudID, (data.entries))
+			continue
+		}
+		break
+	}
 	return r, nil
 }
 
-func (h *DefaultExLgtHolder) PrepareAppend(field *FieldDesc, values *BoolValues) (r Preparation, e error) {
+func (h *ExtendLgtHolder) PrepareAppend(field *FieldDesc, values *BoolValues) (r Preparation, e error) {
 	// util.PanicIf(values.Operator != ValueOptEQ, "default container support EQ operator only")
 
 	switch values.Operator {
 	case ValueOptEQ: // NOTE: ids can be replicated if expression contain cross condition
-		var ids []uint64
-		if ids, e = field.Parser.ParseValue(values.Value); e != nil {
-			return r, fmt.Errorf("field:%s value:%+v parse fail, err:%s", field.Field, values, e.Error())
+		var ids []int64
+		if ids, e = parser.ParseIntergers(values.Value, h.EnableF2I); e != nil {
+			return r, fmt.Errorf("field:%s value:%+v parse fail, err:%v", field.Field, values, e)
 		}
-		r.Data = ids
-	case ValueOptLT:
-
-	case ValueOptGT:
+		r.Data = &prepareData{
+			valueIDs: ids,
+			operator: ValueOptEQ,
+		}
+	case ValueOptLT, ValueOptGT:
+		var number int64
+		if number, e = parser.ParseIntegerNumber(values.Value, h.EnableF2I); e != nil {
+			return r, fmt.Errorf("lt/gt operator need interger, parse:%v err:%v", values.Value, e)
+		}
+		r.Data = &prepareData{
+			lgtValue: number,
+			operator: values.Operator,
+		}
+	default:
+		return
 	}
 	return r, nil
 }
 
 // CommitAppend NOTE: if partial success for a conjunction will cause logic error
 // so for a Holder implement should panic it if any errors happen
-func (h *DefaultExLgtHolder) CommitAppend(preparation *Preparation, eid EntryID) {
+func (h *ExtendLgtHolder) CommitAppend(preparation *Preparation, eid EntryID) {
 	if preparation.Data == nil {
 		return
 	}
-
-	var ok bool
-	var ids []uint64
-	if ids, ok = preparation.Data.([]uint64); !ok {
-		panic(fmt.Errorf("bad preparation.Data type, oops..."))
-	}
-
-	for _, id := range ids {
-		key := NewKey(preparation.field.ID, id)
-		h.plEntries[key] = append(h.plEntries[key], eid)
+	data := preparation.Data.(*prepareData)
+	switch data.operator {
+	case ValueOptEQ: // NOTE: ids can be replicated if expression contain cross condition
+		values := util.DistinctInteger(data.valueIDs)
+		for _, id := range values {
+			h.plEntries[id] = append(h.plEntries[id], eid)
+		}
+	case ValueOptGT:
+		var ok bool
+		var valueEntries *LgtEntries
+		if valueEntries, ok = h._gtmap[data.lgtValue]; !ok || valueEntries == nil {
+			valueEntries = &LgtEntries{
+				lgtValue: data.lgtValue,
+				entries:  Entries{},
+			}
+			h._gtmap[data.lgtValue] = valueEntries
+		}
+		valueEntries.entries = append(valueEntries.entries, eid)
+	case ValueOptLT:
+		var ok bool
+		var valueEntries *LgtEntries
+		if valueEntries, ok = h._ltmap[data.lgtValue]; !ok || valueEntries == nil {
+			valueEntries = &LgtEntries{
+				lgtValue: data.lgtValue,
+				entries:  Entries{},
+			}
+			h._ltmap[data.lgtValue] = valueEntries
+		}
+		valueEntries.entries = append(valueEntries.entries, eid)
+	default:
+		panic(fmt.Errorf("what happened?"))
 	}
 }
 
-func (h *DefaultExLgtHolder) getEntries(key Key) Entries {
+func (h *ExtendLgtHolder) getEntries(key int64) Entries {
 	if entries, hit := h.plEntries[key]; hit {
 		return entries
 	}
 	return nil
 }
 
-func (h *DefaultExLgtHolder) makeEntriesSorted() {
-	var total int64
+func (h *ExtendLgtHolder) makeEntriesSorted() {
+	var total int
+	var valueCnt int
 	for _, entries := range h.plEntries {
 		sort.Sort(entries)
-		if h.maxLen < int64(len(entries)) {
-			h.maxLen = int64(len(entries))
+		if h.maxLen < len(entries) {
+			h.maxLen = len(entries)
 		}
-		total += int64(len(entries))
+		total += len(entries)
 	}
-	if len(h.plEntries) > 0 {
-		h.avgLen = total / int64(len(h.plEntries))
+	for _, data := range h._gtmap {
+		sort.Sort(data.entries)
+		if h.maxLen < len(data.entries) {
+			h.maxLen = len(data.entries)
+		}
+		total += len(data.entries)
+	}
+	for _, data := range h._ltmap {
+		sort.Sort(data.entries)
+		if h.maxLen < len(data.entries) {
+			h.maxLen = len(data.entries)
+		}
+		total += len(data.entries)
+	}
+	valueCnt += len(h.plEntries)
+	valueCnt += len(h.gtEntries)
+	valueCnt += len(h.ltEntries)
+	if valueCnt > 0 {
+		h.avgLen = total / valueCnt
 	}
 }

--- a/entries_holder_ex_ltgt_test.go
+++ b/entries_holder_ex_ltgt_test.go
@@ -1,0 +1,93 @@
+package be_indexer
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestLGTHolder(t *testing.T) {
+	convey.Convey("test holder index expression", t, func() {
+		holder := NewDefaultExtLtGtHolder(true)
+		field := &FieldDesc{
+			FieldOption: FieldOption{Parser: nil, Container: "ut"},
+			ID:          0,
+			Field:       "age",
+		}
+		for i := 0; i < 10; i++ {
+			v := NewBoolValue(ValueOptEQ, []int{10, i%3 + 5}, true)
+			data, e := holder.PrepareAppend(field, &v)
+			convey.So(e, convey.ShouldBeNil)
+			holder.CommitAppend(&data, NewEntryID(ConjID(i+100), true))
+
+			v = NewGTBoolValue(int64(i%3 + 5))
+			data, e = holder.PrepareAppend(field, &v)
+			convey.So(e, convey.ShouldBeNil)
+			holder.CommitAppend(&data, NewEntryID(ConjID(i+50), true))
+
+			v = NewLTBoolValue(int64(i%3 + 5))
+			data, e = holder.PrepareAppend(field, &v)
+			convey.So(e, convey.ShouldBeNil)
+			holder.CommitAppend(&data, NewEntryID(ConjID(i+10), true))
+		}
+		convey.So(holder.CompileEntries(), convey.ShouldBeNil)
+
+		sb := &strings.Builder{}
+		holder.DumpEntries(sb)
+		fmt.Println(sb.String())
+
+		convey.Convey("lt retrieve", func() {
+			plList, e := holder.GetEntries(field, []int64{-100, -1}) // only lt result retrieved
+			convey.So(e, convey.ShouldBeNil)
+			fmt.Println("0:result:", FieldCursors{NewFieldCursor(plList...)}.Dump())
+			vs := make([]int64, 0, 0)
+			for _, pl := range plList {
+				vs = append(vs, pl.key.value.(int64))
+				for _, eid := range pl.entries {
+					convey.So(eid.GetConjID(), convey.ShouldBeBetweenOrEqual, 10, 20)
+				}
+			}
+			convey.So(vs, convey.ShouldResemble, []int64{7, 6, 5}) // reverse order
+		})
+
+		convey.Convey("gt retrieve", func() {
+			plList, e := holder.GetEntries(field, []int64{100, 200}) // only lt result retrieved
+			convey.So(e, convey.ShouldBeNil)
+			fmt.Println("100,200:result:", FieldCursors{NewFieldCursor(plList...)}.Dump())
+			vs := make([]int64, 0, 0)
+			for _, pl := range plList {
+				vs = append(vs, pl.key.value.(int64))
+				for _, eid := range pl.entries {
+					convey.So(eid.GetConjID(), convey.ShouldBeBetweenOrEqual, 50, 60)
+				}
+			}
+			convey.So(vs, convey.ShouldResemble, []int64{5, 6, 7}) // reverse order
+		})
+
+		convey.Convey("gt-lt-kv both retrieve", func() {
+			plList, e := holder.GetEntries(field, []int64{6}) // only lt result retrieved
+			convey.So(e, convey.ShouldBeNil)
+			convey.So(len(plList), convey.ShouldEqual, 3)
+			fmt.Println("6:result:", FieldCursors{NewFieldCursor(plList...)}.Dump())
+			for _, pl := range plList {
+				v := pl.key.value.(int64)
+				switch v {
+				case 5: // should be 6 ">5" retrieved(greater than expression)
+					for _, eid := range pl.entries {
+						convey.So(eid.GetConjID(), convey.ShouldBeBetweenOrEqual, 50, 60)
+					}
+				case 6: // should be "=6" retrieved(in/not in expression)
+					for _, eid := range pl.entries {
+						convey.So(eid.GetConjID(), convey.ShouldBeBetweenOrEqual, 100, 110)
+					}
+				case 7: // should be 6 "<7" retrieved(less than expression)
+					for _, eid := range pl.entries {
+						convey.So(eid.GetConjID(), convey.ShouldBeBetweenOrEqual, 10, 20)
+					}
+				}
+			}
+		})
+	})
+}

--- a/entries_holder_factory.go
+++ b/entries_holder_factory.go
@@ -7,9 +7,9 @@ type (
 )
 
 const (
-	HolderNameDefault      = "default"
-	HolderNameACMatcher    = "ac_matcher"
-	HolderNameDefaultExLgt = "default_ex_lgt"
+	HolderNameDefault     = "default"
+	HolderNameACMatcher   = "ac_matcher"
+	HolderNameExtendLgt = "number_with_lgt"
 )
 
 var holderFactory = make(map[string]HolderBuilder)
@@ -21,8 +21,8 @@ func init() {
 	_ = RegisterEntriesHolder(HolderNameDefault, func() EntriesHolder {
 		return NewDefaultEntriesHolder()
 	})
-	_ = RegisterEntriesHolder(HolderNameDefaultExLgt, func() EntriesHolder {
-		return NewDefaultExtLtGtHolder()
+	_ = RegisterEntriesHolder(HolderNameExtendLgt, func() EntriesHolder {
+		return NewDefaultExtLtGtHolder(true)
 	})
 }
 

--- a/example/be_indexer_usage/main.go
+++ b/example/be_indexer_usage/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/echoface/be_indexer"
-	"github.com/echoface/be_indexer/util"
 )
 
 func buildTestDoc() []*be_indexer.Document {
@@ -12,36 +11,33 @@ func buildTestDoc() []*be_indexer.Document {
 }
 
 func main() {
-	builder := be_indexer.NewIndexerBuilder()
+	builder := be_indexer.NewIndexerBuilder(
+		be_indexer.WithBadConjBehavior(be_indexer.SkipBadConj),
+	)
 	// or use a compacted version, it faster about 12% than default
 	// builder := be_indexer.NewCompactIndexerBuilder()
 
 	// optional special a holder/container for field
+	// dever can also register customized container: see: entries_holder_factory.go
 	builder.ConfigField("keyword", be_indexer.FieldOption{
 		Container: be_indexer.HolderNameACMatcher,
 	})
 
 	for _, doc := range buildTestDoc() {
-		err := builder.AddDocument(doc)
-		util.PanicIfErr(err, "document can't be resolved")
+		_ = builder.AddDocument(doc)
 	}
 
 	indexer := builder.BuildIndex()
 
-	result, e := indexer.Retrieve(map[be_indexer.BEField]be_indexer.Values{
-		"age": be_indexer.NewIntValues(5),
-	})
-	fmt.Println(e, result)
-
-	result, e = indexer.Retrieve(map[be_indexer.BEField]be_indexer.Values{
-		"ip": be_indexer.NewStrValues("localhost"),
-	})
-	fmt.Println(e, result)
-
-	result, e = indexer.Retrieve(map[be_indexer.BEField]be_indexer.Values{
+	// indexing satisfied docs
+	assigns := map[be_indexer.BEField]be_indexer.Values{
 		"age":  be_indexer.NewIntValues(1),
-		"city": be_indexer.NewStrValues("sh"),
-		"tag":  be_indexer.NewStrValues("tag1"),
-	}, be_indexer.WithStepDetail(), be_indexer.WithDumpEntries())
+		"city": be_indexer.NewStrValues("sh", "bj"),
+		"tag":  be_indexer.NewStrValues("tag1", "tagn"),
+	}
+
+	result, e := indexer.Retrieve(assigns,
+		be_indexer.WithStepDetail(),
+		be_indexer.WithDumpEntries())
 	fmt.Println(e, result)
 }

--- a/index_scanner.go
+++ b/index_scanner.go
@@ -200,6 +200,15 @@ func (s FieldCursors) Dump() string {
 	return sb.String()
 }
 
+func (s FieldCursors) DumpJustCursors() string {
+	sb := &strings.Builder{}
+	for _, fc := range s {
+		fc.DumpCursorEntryID(sb)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
 func NewFieldCursor(cursors ...*EntriesCursor) *FieldCursor {
 	scanner := &FieldCursor{
 		current:     nil,
@@ -270,6 +279,20 @@ func (fc *FieldCursor) DumpEntries(sb *strings.Builder) {
 		}
 		it.DumpEntries(sb)
 		sb.WriteString("\n")
+	}
+}
+
+func (fc *FieldCursor) DumpCursorEntryID(sb *strings.Builder) {
+	sb.WriteString("============== Field Cursor EID ==============\n")
+	for _, it := range fc.cursorGroup {
+		if it == fc.current {
+			sb.WriteString(">")
+		} else {
+			sb.WriteString(" ")
+		}
+		sb.WriteString(it.key.String())
+		curEIDStr := it.GetCurEntryID().DocString()
+		sb.WriteString(fmt.Sprintf(",idx:%02d,EID:%s\n", it.cursor, curEIDStr))
 	}
 }
 

--- a/util/slice_util.go
+++ b/util/slice_util.go
@@ -67,6 +67,18 @@ func DistinctInt(vs []int) (res []int) {
 	return res
 }
 
+func DistinctInteger[T Integer](vs []T) (res []T) {
+	m := map[T]struct{}{}
+	for _, v := range vs {
+		m[v] = struct{}{}
+	}
+	res = make([]T, 0, len(m))
+	for v := range m {
+		res = append(res, v)
+	}
+	return res
+}
+
 func RunesToBytes(rs []rune) []byte {
 	size := 0
 	for _, r := range rs {


### PR DESCRIPTION
add a container support operator: >、<、in、not in(Of course =,!=), use for solve the boolean expression like `score > 1` 
eg: 
```
{score > 10 and  city exclude [sh, bj]} 
{score exclude [11, 50] and  city in [sh, bj]} 
```
a example usage can find at: be_indexer_test.go  TestBEIndex_WithExtendLGT