### PR TITLE
feature: add geohash parser for geo indexing support

### DIFF
--- a/be_indexer_test.go
+++ b/be_indexer_test.go
@@ -739,10 +739,7 @@ func TestBEIndexer_Retrieve_Geohash(t *testing.T) {
 			holder := NewDefaultEntriesHolder()
 			holder.FieldParser = map[BEField]parser.FieldValueParser{
 				"tag": parser.NewNumberParser(),
-				"geo": &parser.GeoHashParser{
-					Precision:           7,
-					MinCompressionLevel: 6,
-				},
+				"geo": parser.NewGeoHashParser(nil),
 			}
 			return holder
 		})
@@ -763,14 +760,14 @@ func TestBEIndexer_Retrieve_Geohash(t *testing.T) {
 		results, err := index.Retrieve(map[BEField]Values{
 			"tag": 1000,
 			"geo": [2]float64{31.21275902, 121.53779984},
-		})
+		}, WithStepDetail(), WithDumpEntries())
 		fmt.Println(results, err)
 		convey.So(results.Len(), convey.ShouldEqual, 1)
 
 		results, err = index.Retrieve(map[BEField]Values{
 			"tag": 1000,
 			"geo": [2]float64{30.21275902, 121.53779984},
-		})
+		}, WithStepDetail(), WithDumpEntries())
 		convey.So(results.Len(), convey.ShouldEqual, 0)
 	})
 }

--- a/entries_holder_factory.go
+++ b/entries_holder_factory.go
@@ -13,6 +13,11 @@ const (
 var holderFactory = make(map[string]HolderBuilder)
 
 func init() {
+	InitHolderDefaults()
+}
+
+func InitHolderDefaults() {
+	holderFactory = make(map[string]HolderBuilder)
 	RegisterEntriesHolder(HolderNameDefault, func() EntriesHolder {
 		return NewDefaultEntriesHolder()
 	})
@@ -32,7 +37,7 @@ func HasHolderBuilder(name string) bool {
 
 func RegisterEntriesHolder(name string, builder HolderBuilder) {
 	if HasHolderBuilder(name) {
-		LogInfo("holder name:%s already registered", name)
+		LogInfo("holder name:%s already registered, override!!!", name)
 	}
 	holderFactory[name] = builder
 }

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -5,3 +5,4 @@ compacted_indexer/compacted_indexer
 indexer_benchmark/indexer_benchmark
 indexing_json_doc/indexing_json_doc
 roaringidx_usage/roaringidx_usage
+geohash_exmaple/geohash_exmaple

--- a/example/geohash_exmaple/main.go
+++ b/example/geohash_exmaple/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"github.com/echoface/be_indexer"
+	"github.com/echoface/be_indexer/parser"
+	"github.com/echoface/be_indexer/util"
+)
+
+func main() {
+	be_indexer.RegisterEntriesHolder(be_indexer.HolderNameDefault, func() be_indexer.EntriesHolder {
+		holder := be_indexer.NewDefaultEntriesHolder()
+		holder.FieldParser = map[be_indexer.BEField]parser.FieldValueParser{
+			"tag": parser.NewNumberParser(),
+			"geo": parser.NewGeoHashParser(nil),
+		}
+		return holder
+	})
+
+	// tag in (1,5) && geo in (经纬度半径一公里内) && kws != "adult av")
+	conj := be_indexer.NewConjunction().
+		In("tag", []int64{1, 5}).
+		NotIn("kws", []string{"adult"}).
+		In("geo", "31.21275902:121.53779984:1000")
+	doc := be_indexer.NewDocument(1)
+	doc.AddConjunction(conj)
+
+	b := be_indexer.NewCompactIndexerBuilder()
+	err := b.AddDocument(doc)
+	util.PanicIfErr(err, "add doc fail:%v", err)
+
+	index := b.BuildIndex()
+
+	be_indexer.PrintIndexInfo(index)
+	be_indexer.PrintIndexEntries(index)
+
+	results, err := index.Retrieve(map[be_indexer.BEField]be_indexer.Values{
+		"tag": 1000,
+		"geo": [2]float64{31.21275902, 121.53779984},
+	}, be_indexer.WithStepDetail(), be_indexer.WithDumpEntries())
+	util.PanicIfErr(err, "failed retrieve")
+	util.PanicIf(results.Len() > 0, "need empty result") // tag:1000 不满足
+
+	results, err = index.Retrieve(map[be_indexer.BEField]be_indexer.Values{
+		"tag": 100,
+		"kws": "adult",
+		"geo": [2]float64{31.21275902, 121.53779984},
+	}, be_indexer.WithStepDetail(), be_indexer.WithDumpEntries())
+	util.PanicIfErr(err, "failed retrieve")
+	util.PanicIf(results.Len() > 0, "need empty result") // kws:adult 不满足
+
+	results, err = index.Retrieve(map[be_indexer.BEField]be_indexer.Values{
+		"tag": 1,
+		"geo": [2]float64{31.21275902, 121.53779984},
+	}, be_indexer.WithStepDetail(), be_indexer.WithDumpEntries())
+	util.PanicIfErr(err, "failed retrieve")
+	util.PanicIf(!results.Contain(1), "need has result:1") // 满足
+}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.18
 require (
 	github.com/RoaringBitmap/roaring v0.9.4
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
+	github.com/echoface/proximityhash v0.0.0-20230129144145-e282a3eb9fe1
 	github.com/iohub/ahocorasick v0.0.0-20190713143823-b7bfd8ad9e27
-	github.com/smartystreets/goconvey v1.6.4
+	github.com/mmcloughlin/geohash v0.10.0
+	github.com/smartystreets/goconvey v1.7.2
 	google.golang.org/protobuf v1.28.1
 )
 
@@ -16,5 +18,5 @@ require (
 	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
-	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
+	github.com/smartystreets/assertions v1.2.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/RoaringBitmap/roaring v0.9.4
 	github.com/anknown/ahocorasick v0.0.0-20190904063843-d75dbd5169c0
-	github.com/echoface/proximityhash v0.0.0-20230129144145-e282a3eb9fe1
+	github.com/echoface/proximityhash v0.0.0-20230211105152-91366992edfe
 	github.com/iohub/ahocorasick v0.0.0-20190713143823-b7bfd8ad9e27
 	github.com/mmcloughlin/geohash v0.10.0
 	github.com/smartystreets/goconvey v1.7.2

--- a/parser/geohash_parser.go
+++ b/parser/geohash_parser.go
@@ -1,0 +1,137 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/echoface/be_indexer/util"
+
+	"github.com/echoface/proximityhash"
+	"github.com/mmcloughlin/geohash"
+)
+
+// GeoHashParser turn value into a unique id
+// parser a string fmt geohash region: "lat:lon:radius(m)"
+// geohash长度	误差距离（km）
+//
+//	1	            ±2500
+//	2	            ±630
+//	3	            ±78
+//	4	            ±20
+//	5	            ±2.4
+//	6	            ±0.61
+//	7	            ±0.076
+//	8	            ±0.019
+type GeoHashParser struct {
+	Precision           uint
+	MinCompressionLevel uint
+}
+
+func (p *GeoHashParser) init() {
+	if p.Precision == 0 {
+		p.Precision = 6
+	}
+	if p.MinCompressionLevel == 0 {
+		p.MinCompressionLevel = 4
+	}
+}
+
+func (p *GeoHashParser) Name() string {
+	return "geohash"
+}
+
+func parseLatLonRadius(s string) (lat, lon, r float64, err error) {
+	ss := strings.Split(s, ":")
+	if len(ss) != 3 {
+		return 0, 0, 0, fmt.Errorf("fmt error, need lat:lon:radius")
+	}
+	if lat, err = strconv.ParseFloat(ss[0], 64); err != nil {
+		return
+	}
+	if lon, err = strconv.ParseFloat(ss[1], 64); err != nil {
+		return
+	}
+	if r, err = strconv.ParseFloat(ss[2], 64); err != nil {
+		return
+	}
+	return
+}
+
+func (p *GeoHashParser) genGeoHashID(v string) ([]uint64, error) {
+	lat, lon, r, err := parseLatLonRadius(v)
+	if err != nil {
+		return nil, err
+	}
+	codes := proximityhash.CreateGeohash(lat, lon, r, p.Precision)
+	codes = proximityhash.CompressGeoHash(codes, int(p.MinCompressionLevel))
+
+	results := make([]uint64, len(codes))
+	for idx, code := range codes {
+		id, _ := geohash.ConvertStringToInt(code)
+		results[idx] = id
+	}
+	return results, nil
+}
+
+func (p *GeoHashParser) genQueryAssignGeoHashIDs(lat, lon float64) []uint64 {
+	geohashCode := geohash.Encode(lat, lon)
+	results := make([]uint64, 0, p.Precision)
+	for i := p.MinCompressionLevel; i < p.Precision; i++ {
+		geohashID, _ := geohash.ConvertStringToInt(geohashCode[:i])
+		results = append(results, geohashID)
+	}
+	return results
+}
+
+// ParseAssign parse query assign value into id-encoded ids
+func (p *GeoHashParser) ParseAssign(v interface{}) ([]uint64, error) {
+	switch value := v.(type) {
+	case [2]float64:
+		return p.genQueryAssignGeoHashIDs(value[0], value[1]), nil
+	case []float64:
+		if len(value) != 2 {
+			return nil, fmt.Errorf("need lat/lon value")
+		}
+		return p.genQueryAssignGeoHashIDs(value[0], value[1]), nil
+	default:
+		break
+	}
+	return nil, fmt.Errorf("bad query assign fmt")
+}
+
+// ParseValue parse bool expression value into id-encoded ids
+func (p *GeoHashParser) ParseValue(v interface{}) ([]uint64, error) {
+	switch value := v.(type) {
+	case string:
+		return p.genGeoHashID(value)
+	case []string:
+		results := make([]uint64, 0)
+		for _, v := range value {
+			parts, err := p.genGeoHashID(v)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, parts...)
+		}
+		return util.DistinctInteger(results), nil
+	case []interface{}:
+		results := make([]uint64, 0)
+		for _, vi := range value {
+			s, ok := vi.(string)
+			if !ok {
+				return nil, fmt.Errorf("need format like lat:lon:radius")
+			}
+
+			parts, err := p.genGeoHashID(s)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, parts...)
+		}
+		return util.DistinctInteger(results), nil
+	default:
+		break
+	}
+	return nil, fmt.Errorf("unsupported geohash type")
+}


### PR DESCRIPTION
1: add a geohash parser for indexing lbs/gis boolean expression

eg: 
```bash
# 定向某个位置周围5km内的x粉丝用户投放广告ad01
ad01: geo in ["35.23941:82.76251:5000", "lat:lon:radius] && tag in ["x-fans"]
ad01:  .....

query input:
geo: [lat_value, lon_value]
tag: man

output:
[ad01]
```